### PR TITLE
refactor: consolidate similar functions into one

### DIFF
--- a/src/js/utilities/includeScripts.test.ts
+++ b/src/js/utilities/includeScripts.test.ts
@@ -1,31 +1,25 @@
-import includeScripts, { moduleType, nonBlockingType } from './includeScripts';
+import includeScripts, { attribute } from './includeScripts';
 
 describe('includeScripts', () => {
-  describe('moduleType', () => {
+  describe('attribute', () => {
     it('returns type="module" for module types', () => {
-      expect(moduleType('module')).toEqual(' type="module"');
+      expect(attribute('module')).toEqual(' type="module"');
     });
 
     it('returns nomodule for nomodule types', () => {
-      expect(moduleType('nomodule')).toEqual(' nomodule');
+      expect(attribute('nomodule')).toEqual(' nomodule');
     });
 
-    it('returns an empty string for non-specified types', () => {
-      expect(moduleType()).toEqual('');
-    });
-  });
-
-  describe('nonBlockingType', () => {
     it('returns async for async scripts', () => {
-      expect(nonBlockingType('async')).toEqual(' async');
+      expect(attribute('async')).toEqual(' async');
     });
 
     it('returns defer for defer scripts', () => {
-      expect(nonBlockingType('defer')).toEqual(' defer');
+      expect(attribute('defer')).toEqual(' defer');
     });
 
     it('returns an empty string for non-specified scripts', () => {
-      expect(nonBlockingType()).toEqual('');
+      expect(attribute()).toEqual('');
     });
   });
 

--- a/src/js/utilities/includeScripts.ts
+++ b/src/js/utilities/includeScripts.ts
@@ -4,25 +4,24 @@ interface ScriptDefinition {
   asyncDefer?: 'async' | 'defer';
 }
 
-export const moduleType = (type?: 'module' | 'nomodule'): string => {
+export const attribute = (type?: 'module' | 'nomodule' | 'async' | 'defer'): string => {
   let result = '';
 
-  if (type === 'module') {
-    result = ' type="module"';
-  } else if (type === 'nomodule') {
-    result = ' nomodule';
-  }
-
-  return result;
-};
-
-export const nonBlockingType = (asyncDefer?: 'async' | 'defer'): string => {
-  let result = '';
-
-  if (asyncDefer === 'async') {
-    result = ' async';
-  } else if (asyncDefer === 'defer') {
-    result = ' defer';
+  switch (type) {
+    case 'module':
+      result = ' type="module"';
+      break;
+    case 'nomodule':
+      result = ' nomodule';
+      break;
+    case 'async':
+      result = ' async';
+      break;
+    case 'defer':
+      result = ' defer';
+      break;
+    default:
+      break;
   }
 
   return result;
@@ -30,7 +29,7 @@ export const nonBlockingType = (asyncDefer?: 'async' | 'defer'): string => {
 
 const includeScripts = (scripts: Array<ScriptDefinition>): string => (
   scripts.map((script: ScriptDefinition): string => (
-    `<script src="${script.src}"${moduleType(script.type)}${nonBlockingType(script.asyncDefer)}></script>`
+    `<script src="${script.src}"${attribute(script.type)}${attribute(script.asyncDefer)}></script>`
   )).join('')
 );
 


### PR DESCRIPTION
This simplifies the logic for setting attributes on `<script>` tags for the module/nomodule pattern and async/defer scripts.