### PR TITLE
chore: enable eslint and stylelint plugins in codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -42,13 +42,11 @@ checks:
     config:
       threshold: #language-specific defaults. overrides affect all languages.
 
-# plugins:
-#   eslint:
-#     enabled: true
-#     channel: "eslint-6"
-#   rubocop:
-#     enabled: true
-#     channel: "rubocop-0-79"
+plugins:
+  eslint:
+    enabled: true
+  stylelint:
+    enabled: true
 
 exclude_patterns:
 - "config/"

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,3 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',


### PR DESCRIPTION
This should use stylelint/eslint when reporting issues in codeclimate.